### PR TITLE
fix: Made changes on flow due to wrong Receipt handling

### DIFF
--- a/src/main/java/it/gov/pagopa/wispconverter/exception/AppErrorCodeMessageEnum.java
+++ b/src/main/java/it/gov/pagopa/wispconverter/exception/AppErrorCodeMessageEnum.java
@@ -26,6 +26,8 @@ public enum AppErrorCodeMessageEnum {
     PAYMENT_POSITION_NOT_IN_PAYABLE_STATE(1300, "Existing payment position not in payable state", "Error while generating payment position. One or more of the payment position(s) associated to IUV(s) [{0}] exists but are not in a payable state. All the payments are declared invalid.", HttpStatus.CONFLICT),
     PAYMENT_POSITION_IN_INVALID_STATE(1301, "Existing payment position in invalid state", "Error while generating payment position. There is a payment position associated to IUV [{0}] but it is in an invalid state or it corrupted.", HttpStatus.CONFLICT),
     PAYMENT_POSITION_NOT_VALID(1301, "Existing payment position not valid", "Error while generating payment position. The payment position associated to IUV [{0}] is not valid.", HttpStatus.BAD_REQUEST),
+    PAYMENT_POSITION_NOT_EXTRACTABLE(1302, "Existing payment position not valid", "Error while generating payment position. An error occurred while trying to analyze payment position.", HttpStatus.BAD_REQUEST),
+    RECEIPT_KO_NOT_GENERATED(1400, "KO Receipt not generated", "Error while generating KO receipt. It is not possible to generate the receipt due to an error: [{0}].", HttpStatus.UNPROCESSABLE_ENTITY),
     // --- DB and storage interaction errors ---
     PERSISTENCE_RPT_NOT_FOUND(2000, "RPT not found", "Error while retrieving RPT. RPT with sessionId [{0}] not found.", HttpStatus.NOT_FOUND),
     PERSISTENCE_REQUESTID_CACHING_ERROR(2001, "RequestID caching error", "Error while reading cached RequestID. No valid value found for key [{0}].", HttpStatus.UNPROCESSABLE_ENTITY),
@@ -36,8 +38,7 @@ public enum AppErrorCodeMessageEnum {
     CLIENT_IUVGENERATOR(3002, "IUV Generator client error", "Error while communicating with IUV Generator service. {0}", HttpStatus.EXPECTATION_FAILED),
     CLIENT_DECOUPLER_CACHING(3003, "Decoupler caching client error", "Error while communicating with decoupler caching API. {0}", HttpStatus.EXPECTATION_FAILED),
     CLIENT_CHECKOUT(3004, "Checkout error", "Error while communicating with Checkout service. {0}", HttpStatus.EXPECTATION_FAILED),
-    CLIENT_PAAINVIART(3005, "PaaInviaRT error", "Error while communicating with Station for paaInviaRT service. {0}", HttpStatus.EXPECTATION_FAILED)
-    ;
+    CLIENT_PAAINVIART(3005, "PaaInviaRT error", "Error while communicating with Station for paaInviaRT service. {0}", HttpStatus.EXPECTATION_FAILED);
 
     private final Integer code;
     private final String title;

--- a/src/main/java/it/gov/pagopa/wispconverter/service/ConverterService.java
+++ b/src/main/java/it/gov/pagopa/wispconverter/service/ConverterService.java
@@ -33,6 +33,7 @@ public class ConverterService {
 
         // unmarshalling and mapping RPT content from request entity, generating session data
         SessionDataDTO sessionData = this.rptExtractorService.extractSessionData(rptRequestEntity.getPrimitive(), rptRequestEntity.getPayload());
+        sessionData.getCommonFields().setSessionId(sessionId);
 
         // calling GPD creation API in order to generate the debt position associated to RPTs
         this.debtPositionService.createDebtPositions(sessionData);

--- a/src/main/java/it/gov/pagopa/wispconverter/service/DecouplerService.java
+++ b/src/main/java/it/gov/pagopa/wispconverter/service/DecouplerService.java
@@ -103,7 +103,7 @@ public class DecouplerService {
         apiInstance.saveMapping(decouplerCachingKeys, MDC.get(Constants.MDC_REQUEST_ID));
     }
 
-    private void saveMappedKeyForReceiptGeneration(String sessionId, SessionDataDTO sessionData, String creditorInstitutionId) {
+    public void saveMappedKeyForReceiptGeneration(String sessionId, SessionDataDTO sessionData, String creditorInstitutionId) {
 
         for (PaymentNoticeContentDTO paymentNoticeContentDTO : sessionData.getAllPaymentNotices()) {
 

--- a/src/main/java/it/gov/pagopa/wispconverter/service/ReceiptService.java
+++ b/src/main/java/it/gov/pagopa/wispconverter/service/ReceiptService.java
@@ -123,7 +123,7 @@ public class ReceiptService {
                 });
             });
         } catch (JsonProcessingException e) {
-            throw new AppException(AppErrorCodeMessageEnum.PARSING_INVALID_BODY);
+            throw new AppException(AppErrorCodeMessageEnum.PARSING_INVALID_BODY, e.getMessage());
         } catch (AppException appEx) {
             throw appEx;
         } catch (Exception e) {

--- a/src/main/java/it/gov/pagopa/wispconverter/service/mapper/DebtPositionMapper.java
+++ b/src/main/java/it/gov/pagopa/wispconverter/service/mapper/DebtPositionMapper.java
@@ -24,7 +24,7 @@ public interface DebtPositionMapper {
     @Mapping(source = "commonFields.payerEmail", target = "email")
     @Mapping(source = "commonFields.payerFullName", target = "companyName")
     @Mapping(target = "validityDate", expression = "java(null)")
-    @Mapping(target = "switchToExpired", constant = "true")
+    @Mapping(target = "switchToExpired", constant = "false")
     @Mapping(target = "payStandIn", constant = "false")
     it.gov.pagopa.gen.wispconverter.client.gpd.model.PaymentPositionModelDto toPaymentPosition(SessionDataDTO sessionData);
 

--- a/src/main/java/it/gov/pagopa/wispconverter/service/model/session/CommonFieldsDTO.java
+++ b/src/main/java/it/gov/pagopa/wispconverter/service/model/session/CommonFieldsDTO.java
@@ -11,6 +11,7 @@ import lombok.*;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CommonFieldsDTO {
 
+    private String sessionId;
     private String cartId;
     private String creditorInstitutionId;
     private String creditorInstitutionBrokerId;


### PR DESCRIPTION
After a test session on which the whole flow is tested, some bugs were found. This PR aims to resolve these bugs and add more flexibility on future development, refactoring some existing code in more stable one.

#### List of Changes
 - Fixed error on amount setting, wrongly casted as long value
 - Set `switchToExpired` always to false in debt position creation
 - Set `dueDate` always as _today+1_ in debt position update
 - Better handling of invalid debt positions, preparing all for receipt generation
 - Changed RE generation on invalid debt position analysis, moved before receipt generation

#### Motivation and Context
These changes are required in order to fix the flow and correctly handle RPT payments.

#### How Has This Been Tested?
 - Tested in local environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
