### PR TITLE
[PAGOPA-1921] fix: resolved bug on paaInviaRT duplicated send 

### DIFF
--- a/src/main/java/it/gov/pagopa/wispconverter/service/ReceiptService.java
+++ b/src/main/java/it/gov/pagopa/wispconverter/service/ReceiptService.java
@@ -131,10 +131,11 @@ public class ReceiptService {
                             commonFields.getStationId());
 
                     /*
-                      For each RPT extracted from session data, is necessary to generate a single paaInviaRT SOAP request.
+                      For each RPT extracted from session data that is required by paSendRTV2, is necessary to generate a single paaInviaRT SOAP request.
                       Each paaInviaRT generated will be autonomously sent to creditor institution in order to track each RPT.
                      */
-                    for (RPTContentDTO rpt : sessionData.getAllRPTs()) {
+                    List<RPTContentDTO> rpts = extractRequiredRPTs(sessionData, cachedMapping.getIuv(), cachedMapping.getFiscalCode());
+                    for (RPTContentDTO rpt : rpts) {
 
                         // Generating the paaInviaRT payload from the RPT
                         String paymentOutcome = "Annullato da WISP"; // TODO change this with one of the following -> https://pagopa.atlassian.net/wiki/spaces/PN5/pages/913244345/WISP-Converter?focusedCommentId=1002078407
@@ -206,10 +207,11 @@ public class ReceiptService {
             } else {
 
                 /*
-                  For each RPT extracted from session data, is necessary to generate a single paaInviaRT SOAP request.
+                  For each RPT extracted from session data that is required by paSendRTV2, is necessary to generate a single paaInviaRT SOAP request.
                   Each paaInviaRT generated will be autonomously sent to creditor institution in order to track each RPT.
                 */
-                for (RPTContentDTO rpt : sessionData.getAllRPTs()) {
+                List<RPTContentDTO> rpts = extractRequiredRPTs(sessionData, receipt.getCreditorReferenceId(), receipt.getFiscalCode());
+                for (RPTContentDTO rpt : rpts) {
 
                     // generate the header for the paaInviaRT SOAP request. This object is different for each generated request
                     IntestazionePPT intestazionePPT = generateHeader(
@@ -326,6 +328,11 @@ public class ReceiptService {
         return isSuccessful;
     }
 
+    private List<RPTContentDTO> extractRequiredRPTs(SessionDataDTO sessionData, String iuv, String creditorInstiutionId) {
+        return sessionData.getAllRPTs().stream()
+                .filter(rpt -> rpt.getIuv().equals(iuv) && rpt.getRpt().getDomain().getDomainId().equals(creditorInstiutionId))
+                .toList();
+    }
 
     private CtRicevutaTelematica generateRTContentForKoReceipt(RPTContentDTO rpt, Map<String, ConfigurationKeyDto> configurations, Instant now, String paymentOutcome) {
 

--- a/src/main/java/it/gov/pagopa/wispconverter/service/mapper/RTMapper.java
+++ b/src/main/java/it/gov/pagopa/wispconverter/service/mapper/RTMapper.java
@@ -183,7 +183,7 @@ public abstract class RTMapper {
     @Mapping(source = "ctReceiptV2.paymentDateTime", target = "dataEsitoSingoloPagamento")
     @Mapping(source = "ctReceiptV2.receiptId", target = "identificativoUnivocoRiscossione")
     @Mapping(source = "ctTransferPAReceiptV2.remittanceInformation", target = "causaleVersamento")
-    @Mapping(target = "datiSpecificiRiscossione", expression = "java(extractMetadata(ctTransferPAReceiptV2.getMetadata().getMapEntry()))")
+    @Mapping(target = "datiSpecificiRiscossione", expression = "java(ctTransferPAReceiptV2.getMetadata() != null ? extractMetadata(ctTransferPAReceiptV2.getMetadata().getMapEntry()) : \"\")")
     @Mapping(source = "ctReceiptV2.fee", target = "commissioniApplicatePSP")
     public abstract CtDatiSingoloPagamentoRT toCtDatiSingoloPagamentoRTForOkRT(CtTransferPAReceiptV2 ctTransferPAReceiptV2, CtReceiptV2 ctReceiptV2);
 

--- a/src/test/java/it/gov/pagopa/wispconverter/endpoint/ReceiptTest.java
+++ b/src/test/java/it/gov/pagopa/wispconverter/endpoint/ReceiptTest.java
@@ -207,7 +207,7 @@ class ReceiptTest {
         // mocking RPT retrieve
         RPTRequestEntity rptRequestEntity = RPTRequestEntity.builder()
                 .primitive("nodoInviaRPT")
-                .payload(TestUtils.zipAndEncode(TestUtils.getRptPayload(false, STATION_ID, "100.00", "datispec")))
+                .payload(TestUtils.zipAndEncode(TestUtils.getRptPayload(false, STATION_ID, "77777777777", "48111111112222222", "100.00", "datispec")))
                 .build();
         when(rptRequestRepository.findById(anyString())).thenReturn(Optional.of(rptRequestEntity));
 
@@ -406,12 +406,12 @@ class ReceiptTest {
         setConfigCacheStoredData("/creditorinstitution/station", 2);
 
         // mocking decoupler cached keys
-        when(cacheRepository.read(anyString(), any())).thenReturn("wisp_nav2iuv_123456IUVMOCK1");
+        when(cacheRepository.read(anyString(), any())).thenReturn("wisp_{pa}_48111111112222222");
 
         // mocking RPT retrieve
         RPTRequestEntity rptRequestEntity = RPTRequestEntity.builder()
                 .primitive("nodoInviaRPT")
-                .payload(TestUtils.zipAndEncode(TestUtils.getRptPayload(false, STATION_ID, "100.00", "datispec")))
+                .payload(TestUtils.zipAndEncode(TestUtils.getRptPayload(false, STATION_ID, "{pa}", "48111111112222222", "100.00", "datispec")))
                 .build();
         when(rptRequestRepository.findById(anyString())).thenReturn(Optional.of(rptRequestEntity));
 

--- a/src/test/java/it/gov/pagopa/wispconverter/utils/TestUtils.java
+++ b/src/test/java/it/gov/pagopa/wispconverter/utils/TestUtils.java
@@ -200,18 +200,24 @@ public class TestUtils {
                 .replaceAll("\\{amount}", amount);
     }
 
-    public static String getRptPayload(boolean bollo, String station, String amount, String datiSpecificiRiscossione) {
+    public static String getRptPayload(boolean bollo, String station, String pa, String iuv, String amount, String datiSpecificiRiscossione) {
         if (datiSpecificiRiscossione == null) {
             datiSpecificiRiscossione = "9/tipodovuto_7/datospecifico";
         }
         String rpt = TestUtils.loadFileContent(bollo ? "/requests/rptBollo.xml" : "/requests/rpt.xml");
         String rptreplace = rpt
                 .replace("{datiSpecificiRiscossione}", datiSpecificiRiscossione)
+                .replace("{pa}", pa)
+                .replace("{iuv}", iuv)
                 .replaceAll("\\{amount}", amount);
         String nodoInviaRPT = TestUtils.loadFileContent("/requests/nodoInviaRPT.xml");
         return nodoInviaRPT
                 .replace("{station}", station)
                 .replace("{rpt}", Base64.getEncoder().encodeToString(rptreplace.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    public static String getRptPayload(boolean bollo, String station, String amount, String datiSpecificiRiscossione) {
+        return getRptPayload(bollo, station, "{pa}", "123456IUVMOCK1", amount, datiSpecificiRiscossione);
     }
 
     public static String getRptNullIbanPayload(String station, String amount, String datiSpecificiRiscossione) {

--- a/src/test/resources/requests/paSendRTV2.xml
+++ b/src/test/resources/requests/paSendRTV2.xml
@@ -39,7 +39,7 @@
                         <transferCategory>0101100IM</transferCategory>
                         <metadata>
                             <mapEntry>
-                                <key>keytest</key>
+                                <key>datiSpecificiRiscossione</key>
                                 <value>1</value>
                             </mapEntry>
                         </metadata>

--- a/src/test/resources/requests/rpt.xml
+++ b/src/test/resources/requests/rpt.xml
@@ -24,7 +24,7 @@
         <dataEsecuzionePagamento>{dataEsecuzionePagamento}</dataEsecuzionePagamento>
         <importoTotaleDaVersare>{amount}</importoTotaleDaVersare>
         <tipoVersamento>{tipoVersamento}</tipoVersamento>
-        <identificativoUnivocoVersamento>123456IUVMOCK1</identificativoUnivocoVersamento>
+        <identificativoUnivocoVersamento>{iuv}</identificativoUnivocoVersamento>
         <codiceContestoPagamento>{ccp}</codiceContestoPagamento>
         <firmaRicevuta>0</firmaRicevuta>
         <datiSingoloVersamento>


### PR DESCRIPTION
This PR contains the resolution of a bug related to the `paaInviaRT` send operation. In particular, the operation was wrong because the send was tried several times ignoring the arrived `paSendRTV2` request. 

#### List of Changes
 - add `iuv-domainId` filter for paaInviaRT send
 - resolved bug on null metadata on `datiSpecificiRiscossione` extraction
 
#### Motivation and Context
These fixes are required in order to resolve the duplicated send operations

#### How Has This Been Tested?
 - Tested in local environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
