### PR TITLE
[PAGOPA-1928] fix: add 'Content-Type' header for paaInviaRT request

### DIFF
--- a/src/main/java/it/gov/pagopa/wispconverter/util/CommonUtility.java
+++ b/src/main/java/it/gov/pagopa/wispconverter/util/CommonUtility.java
@@ -91,6 +91,7 @@ public class CommonUtility {
     public static List<Pair<String, String>> constructHeadersForPaaInviaRT(String startingUrl, StationDto station, String stationInForwarderPartialPath, String forwarderSubscriptionKey) {
         List<Pair<String, String>> headers = new LinkedList<>();
         headers.add(Pair.of("SOAPAction", "paaInviaRT"));
+        headers.add(Pair.of("Content-Type", "text/xml"));
         if (startingUrl.contains(stationInForwarderPartialPath) && station.getService() != null) {
             ServiceDto stationService = station.getService();
             headers.add(Pair.of("X-Host-Url", stationService.getTargetHost() == null ? "ND" : stationService.getTargetHost()));


### PR DESCRIPTION
This PR contains a little fix made on `paaInviaRT` sender, adding the `Content-Type` header, often required on old systems. 

#### List of Changes
 - Add `Content-Type: text/xml` on `paaInviaRT` request 

#### Motivation and Context
This change is required in order to provide better integration with creditor institution services

#### How Has This Been Tested?
 - Tested in UAT environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
