### PR TITLE
[PAGOPA-1940] fix: resolved bug on wrong stamp conversion

### DIFF
--- a/src/main/java/it/gov/pagopa/wispconverter/service/mapper/RPTMapper.java
+++ b/src/main/java/it/gov/pagopa/wispconverter/service/mapper/RPTMapper.java
@@ -93,7 +93,7 @@ public interface RPTMapper {
     TransferDTO toTransferDTO(CtDatiSingoloVersamentoRPT datiSingoloVersamentoRPT);
 
     @Mapping(source = "tipoBollo", target = "type")
-    @Mapping(source = "hashDocumento", target = "documentHash")
+    @Mapping(target = "documentHash", expression = "java(java.util.Base64.getEncoder().encode(datiMarcaBolloDigitale.getHashDocumento()))")
     @Mapping(source = "provinciaResidenza", target = "province")
     DigitalStampDTO toDigitalStampDTO(CtDatiMarcaBolloDigitale datiMarcaBolloDigitale);
 }


### PR DESCRIPTION
This PR contains a fix on a bug found during a test with real creditor institution. This bug is related to the digital stamps (Marca da Bollo Digitale) because its insertion in GPD debt position was wrongly formed. Nodo dei Pagamenti found the error because the generated data was greater than a defined dimension. The error was related to a wrong conversion from bytearray to Base64 format.  

#### List of Changes
 - Resolved missing encoding conversion of digital stamp from Base64 

#### Motivation and Context
This change is required in order to resolve a bug on digital stamp

#### How Has This Been Tested?
 - Tested in local environment
 - Tested in UAT environment 

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
