### PR TITLE
[PAGOPA-2013] fix: add MDC content clearing after timeout-trigger

### DIFF
--- a/src/main/java/it/gov/pagopa/wispconverter/servicebus/PaymentTimeoutConsumer.java
+++ b/src/main/java/it/gov/pagopa/wispconverter/servicebus/PaymentTimeoutConsumer.java
@@ -65,6 +65,7 @@ public class PaymentTimeoutConsumer extends SBConsumer {
             log.error("Error when read ReceiptDto value from message: '{}'. Body: '{}'",
                     message.getMessageId(), message.getBody());
         }
+        MDC.clear();
     }
 
     private void generateREForPaymentTokenTimeout(ReceiptDto receipt) {


### PR DESCRIPTION
By running a query on RE WISP, it was found that two execution streams of the payment-token-timeout-trigger logic (payment token deletion trigger after timeout) were overlapping due to an incorrect setting of the `sessionId` field in the log. This is caused by the MDC session data not being correctly cleaned when terminating the process.

#### List of Changes
 - Add MDC clearing at the end of `payment-token-timeout-trigger` execution

#### Motivation and Context
This fix is required in order to not overlap on other flows during RE queries

#### How Has This Been Tested?
 - Tested in local environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
