### PR TITLE
fix: New resource limits on PROD environment

### DIFF
--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -47,7 +47,7 @@ microservice-chart:
       memory: "640Mi"
       cpu: "200m"
     limits:
-      memory: "1512Mi"
+      memory: "2048Mi"
       cpu: "1000m"
   autoscaling:
     enable: true
@@ -63,7 +63,7 @@ microservice-chart:
       - type: memory
         metricType: Utilization
         metadata:
-          value: "80"
+          value: "200"
     advanced:
       horizontalPodAutoscalerConfig:
         behavior:
@@ -80,7 +80,7 @@ microservice-chart:
                 value: 100
                 periodSeconds: 20
   envConfig:
-    JAVA_OPTS: "-XX:MaxHeapSize=1268m -XX:MinHeapSize=64m"
+    JAVA_OPTS: "-XX:MaxHeapSize=1780m -XX:MinHeapSize=64m"
     WEBSITE_SITE_NAME: 'pagopawispconverter' # required to show cloud role name in application insights
     ENV: 'aks-prod'
     APP_LOGGING_LEVEL: 'INFO'


### PR DESCRIPTION
This PR is made as **_proposal_** in order to define new values for resource limits on production environment.  
During common execution, the pod was killed by an OutOfMemory error, caused by the cache refresh. The memory usage reached over 1.7Gi (with 1024Mi as limit) and the virtual machine was prematurely killed not permitting the AKS' Deployment resource to correctly scale-up the pod. This caused a disruption of the service and two payments were not correctly executed (ended with HTTP error 503). Just before the OOM error, memory usage reached a constant value over 1000Mi (but not over 1024Mi) and no new pod is instantiated.  
With this PR, the upper memory limit is slightly changed on 1.5Gi and a trigger on memory usage is added in order to force the scaling-up if too much memory is used. 

#### List of Changes
 - Incremented memory upper limit usage from 1024Mi
 - add autoscaling trigger on memory usage over certain percentage

#### Motivation and Context
This change is **_proposed_** in order to avoid other OOM errors with service disruption

#### How Has This Been Tested?
 - No test made

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
