### PR TITLE
[PAGOPA-2080] fix: Adjust `id` when find RT

### DIFF
--- a/src/main/java/it/gov/pagopa/wispconverter/service/RtReceiptCosmosService.java
+++ b/src/main/java/it/gov/pagopa/wispconverter/service/RtReceiptCosmosService.java
@@ -24,6 +24,7 @@ import java.time.ZonedDateTime;
 public class RtReceiptCosmosService {
 
     private final RTRepository rtRepository;
+    private static final String ILLEGAL_CHARS_FOR_ID = "[/\\\\#]";
 
     @Transactional
     public void saveRTEntity(SessionDataDTO sessionData) {
@@ -48,6 +49,8 @@ public class RtReceiptCosmosService {
 
     public boolean receiptRtExist(String domainId, String iuv, String ccp) {
         String id = String.format("%s_%s_%s", domainId, iuv, ccp);
+        // Remove illegal characters ['/', '\', '#'] because cannot be used in Resource ID
+        id = id.replaceAll(ILLEGAL_CHARS_FOR_ID, "");
         return rtRepository.findById(id, new PartitionKey(id)).isPresent();
     }
 
@@ -59,8 +62,7 @@ public class RtReceiptCosmosService {
         String id = String.format("%s_%s_%s", domainId, iuv, ccp);
 
         // Remove illegal characters ['/', '\', '#'] because cannot be used in Resource ID
-        String regex = "[/\\\\#]";
-        id = id.replaceAll(regex, "");
+        id = id.replaceAll(ILLEGAL_CHARS_FOR_ID, "");
 
         return RTEntity.builder()
                 .id(id)


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- Update `receiptRtExist` method

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

When reading the `RT`, the illegal characters should be removed from the`id`

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
