### PR TITLE
[PAGOPA-2086] feat: add endpoint for expose static error page

### DIFF
--- a/src/main/java/it/gov/pagopa/wispconverter/controller/StaticPagesController.java
+++ b/src/main/java/it/gov/pagopa/wispconverter/controller/StaticPagesController.java
@@ -1,0 +1,14 @@
+package it.gov.pagopa.wispconverter.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller()
+@RequestMapping("/static")
+public class StaticPagesController {
+
+    @RequestMapping("/error")
+    public String error() {
+        return "error";
+    }
+}

--- a/src/main/java/it/gov/pagopa/wispconverter/controller/StaticPagesController.java
+++ b/src/main/java/it/gov/pagopa/wispconverter/controller/StaticPagesController.java
@@ -1,13 +1,14 @@
 package it.gov.pagopa.wispconverter.controller;
 
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller()
 @RequestMapping("/static")
 public class StaticPagesController {
 
-    @RequestMapping("/error")
+    @GetMapping(path = "/error")
     public String error() {
         return "error";
     }

--- a/src/test/java/it/gov/pagopa/wispconverter/endpoint/StaticPagesTest.java
+++ b/src/test/java/it/gov/pagopa/wispconverter/endpoint/StaticPagesTest.java
@@ -77,10 +77,10 @@ public class StaticPagesTest {
     private ReceiptService receiptService;
 
     /*
-     * CREATE receipt/timer
+     * GET static/error
      * */
     @Test
-    public void testCreateTimer() throws Exception {
+    public void testErrorStaticPage() throws Exception {
 
         mockMvc.perform(get("/static/error"))
                 .andExpect(status().isOk())

--- a/src/test/java/it/gov/pagopa/wispconverter/endpoint/StaticPagesTest.java
+++ b/src/test/java/it/gov/pagopa/wispconverter/endpoint/StaticPagesTest.java
@@ -1,0 +1,89 @@
+package it.gov.pagopa.wispconverter.endpoint;
+
+import com.azure.cosmos.CosmosClientBuilder;
+import com.azure.messaging.servicebus.ServiceBusSenderClient;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import it.gov.pagopa.wispconverter.Application;
+import it.gov.pagopa.wispconverter.repository.*;
+import it.gov.pagopa.wispconverter.service.*;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.metrics.ApplicationStartup;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.client.RestClient;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles(profiles = "test")
+@SpringBootTest(classes = Application.class)
+@AutoConfigureMockMvc
+public class StaticPagesTest {
+    @Autowired
+    ObjectMapper objectMapper;
+    @Autowired
+    private MockMvc mvc;
+    @Autowired
+    private ConfigCacheService configCacheService;
+    @MockBean
+    private ApplicationStartup applicationStartup;
+    @MockBean
+    private RPTRequestRepository rptRequestRepository;
+    @MockBean
+    private RTRetryRepository rtRetryRepository;
+    @MockBean
+    private RTRepository rtRepository;
+    @MockBean
+    private it.gov.pagopa.gen.wispconverter.client.iuvgenerator.invoker.ApiClient iuveneratorClient;
+    @MockBean
+    private it.gov.pagopa.gen.wispconverter.client.gpd.invoker.ApiClient gpdClient;
+    @MockBean
+    private it.gov.pagopa.gen.wispconverter.client.checkout.invoker.ApiClient checkoutClient;
+    @MockBean
+    private it.gov.pagopa.gen.wispconverter.client.cache.invoker.ApiClient cacheClient;
+    @MockBean
+    private it.gov.pagopa.gen.wispconverter.client.decouplercaching.invoker.ApiClient decouplerCachingClient;
+    @MockBean
+    private PaaInviaRTSenderService paaInviaRTService;
+    @MockBean
+    private ServiceBusService paaInviaRTServiceBusService;
+    @MockBean
+    private ServiceBusSenderClient serviceBusSenderClient;
+    @MockBean
+    private RestClient.Builder restClientBuilder;
+    @MockBean
+    private CosmosClientBuilder cosmosClientBuilder;
+    @Qualifier("redisSimpleTemplate")
+    @MockBean
+    private RedisTemplate<String, Object> redisSimpleTemplate;
+    @MockBean
+    private ReEventRepository reEventRepository;
+    @MockBean
+    private CacheRepository cacheRepository;
+    @MockBean
+    private IdempotencyKeyRepository idempotencyKeyRepository;
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private ReceiptTimerService receiptTimerService;
+    @MockBean
+    private ReceiptService receiptService;
+
+    /*
+     * CREATE receipt/timer
+     * */
+    @Test
+    public void testCreateTimer() throws Exception {
+
+        mockMvc.perform(get("/static/error"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("text/html;charset=UTF-8"));
+    }
+}


### PR DESCRIPTION
This PR contains a new endpoint that permits to expose static HTML resources in order to be used from APIM policy.

#### List of Changes
 - Add new endpoint for the exposition of error landing static page

#### Motivation and Context
This feature is required in order to use the static pages in other contexts without duplicating the HTML code

#### How Has This Been Tested?
 - Tested in local environment

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
