### PR TITLE
[PAGOPA-2208] fix: segregation code changed from 48 to 51

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -117,7 +117,7 @@ wisp-converter.re-tracing.internal.checkout-interaction.enabled=${RE_TRACING_INT
 # Application domain configuration
 exception.error-code.uri=${ERROR_CODE_URI:https://pagopa.gov/error-code}
 wisp-converter.aux-digit=3
-wisp-converter.segregation-code=48
+wisp-converter.segregation-code=51
 wisp-converter.payment-position-valid-status=VALID
 wisp-converter.station-in-gpd.partial-path=${STATION_IN_GPD_PARTIAL_PATH:gpd-payments/api/v1}
 wisp-converter.station-in-forwarder.partial-path=${STATION_IN_FORWARDER_PARTIAL_PATH:pagopa-node-forwarder/api/v1/forward}


### PR DESCRIPTION
This PR contains a change made on segregation code used by WISP Dismantling process. Since some creditor institutions already use a station related to segregation code with value 48, in order to avoid the destruction of those stations the same code is changed in the flow.

#### List of Changes
 - Changed segregation code related to WISP Dismantling logic, from value 48 to 51

#### Motivation and Context
This change is required in order to resolve conflicts with existing station related to old segregation code.

#### How Has This Been Tested?


#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.