### PR TITLE
[PAGOPA-2238] fix: refactored max retries for paaInviaRT send

### DIFF
--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -34,9 +34,9 @@ microservice-chart:
     servicePort: 8080
   serviceAccount:
     create: false
-    annotations: {}
+    annotations: { }
     name: ""
-  podAnnotations: {}
+  podAnnotations: { }
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
@@ -96,7 +96,7 @@ microservice-chart:
     CLIENT_DECOUPLERCACHING_HOST: 'https://api.dev.platform.pagopa.it/wisp-converter/caching/api/v1'
     CLIENT_CACHE_HOST: 'https://api.dev.platform.pagopa.it/api-config-cache/p/v1'
     STATION_IN_GPD_PARTIAL_PATH: 'gpd-payments/api/v1'
-    RT_SEND_MAX_RETRIES: '48'
+    RT_SEND_MAX_RETRIES: '5'
     RT_SEND_SCHEDULING_TIME_IN_MINUTES: '1'
     RT_SEND_AVOID_SCHEDULING_ON_STATES: 'PAA_RT_DUPLICATA'
     RPT_TIMER_QUEUE_NAME: "nodo_wisp_rpt_timeout_queue"
@@ -140,8 +140,8 @@ microservice-chart:
       tenantId: "7788edaf-0346-4068-9d79-c868aed15b3d"
   tmpVolumeMount:
     create: true
-  nodeSelector: {}
-  tolerations: []
+  nodeSelector: { }
+  tolerations: [ ]
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -168,5 +168,5 @@ microservice-chart:
         repository: ghcr.io/pagopa/pagopa-wisp-converter
         tag: "0.0.0"
         pullPolicy: Always
-      envConfig: {}
-      envSecret: {}
+      envConfig: { }
+      envSecret: { }

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -34,9 +34,9 @@ microservice-chart:
     servicePort: 8080
   serviceAccount:
     create: false
-    annotations: {}
+    annotations: { }
     name: ""
-  podAnnotations: {}
+  podAnnotations: { }
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
@@ -115,7 +115,7 @@ microservice-chart:
     CLIENT_DECOUPLERCACHING_HOST: 'https://api.platform.pagopa.it/wisp-converter/caching/api/v1'
     CLIENT_CACHE_HOST: 'https://api.platform.pagopa.it/api-config-cache/p/v1'
     STATION_IN_GPD_PARTIAL_PATH: 'gpd-payments/api/v1'
-    RT_SEND_MAX_RETRIES: '48'
+    RT_SEND_MAX_RETRIES: '5'
     RT_SEND_SCHEDULING_TIME_IN_MINUTES: '60'
     RT_SEND_AVOID_SCHEDULING_ON_STATES: 'PAA_RT_DUPLICATA'
     RPT_TIMER_QUEUE_NAME: "nodo_wisp_rpt_timeout_queue"
@@ -159,8 +159,8 @@ microservice-chart:
       tenantId: "7788edaf-0346-4068-9d79-c868aed15b3d"
   tmpVolumeMount:
     create: true
-  nodeSelector: {}
-  tolerations: []
+  nodeSelector: { }
+  tolerations: [ ]
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -187,5 +187,5 @@ microservice-chart:
         repository: ghcr.io/pagopa/pagopa-wisp-converter
         tag: "0.0.0"
         pullPolicy: Always
-      envConfig: {}
-      envSecret: {}
+      envConfig: { }
+      envSecret: { }

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -34,9 +34,9 @@ microservice-chart:
     servicePort: 8080
   serviceAccount:
     create: false
-    annotations: {}
+    annotations: { }
     name: ""
-  podAnnotations: {}
+  podAnnotations: { }
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
@@ -96,7 +96,7 @@ microservice-chart:
     CLIENT_DECOUPLERCACHING_HOST: 'https://api.uat.platform.pagopa.it/wisp-converter/caching/api/v1'
     CLIENT_CACHE_HOST: 'https://api.uat.platform.pagopa.it/api-config-cache/p/v1'
     STATION_IN_GPD_PARTIAL_PATH: 'gpd-payments/api/v1'
-    RT_SEND_MAX_RETRIES: '48'
+    RT_SEND_MAX_RETRIES: '5'
     RT_SEND_SCHEDULING_TIME_IN_MINUTES: '60'
     RT_SEND_AVOID_SCHEDULING_ON_STATES: 'PAA_RT_DUPLICATA'
     RPT_TIMER_QUEUE_NAME: "nodo_wisp_rpt_timeout_queue"
@@ -140,8 +140,8 @@ microservice-chart:
       tenantId: "7788edaf-0346-4068-9d79-c868aed15b3d"
   tmpVolumeMount:
     create: true
-  nodeSelector: {}
-  tolerations: []
+  nodeSelector: { }
+  tolerations: [ ]
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -168,5 +168,5 @@ microservice-chart:
         repository: ghcr.io/pagopa/pagopa-wisp-converter
         tag: "0.0.0"
         pullPolicy: Always
-      envConfig: {}
-      envSecret: {}
+      envConfig: { }
+      envSecret: { }

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -104,7 +104,7 @@ microservice-chart:
     CRON_JOB_SCHEDULE_RECOVERY_RECEIPT_KO_ENABLED: '0 0 * * * *' # top of every hour of every day
     CRON_JOB_SCHEDULE_RECOVERY_FROM_HOURS_AGO: '2' # from 2 hours ago
     CRON_JOB_SCHEDULE_RECOVERY_UNTIL_HOURS_AGO: '1' # until 1 hours ago
-    RPT_TIMEOUT: '60' # 1 minute (set for integration tests)
+    RPT_TIMEOUT: '300' # 5 minutes
     RE_TRACING_INTERFACE_IUVGENERATOR_ENABLED: 'true'
     RE_TRACING_INTERFACE_PAYMENTPOSITIONANALYSIS_ENABLED: 'true'
     RE_TRACING_INTERFACE_DECOUPLERCACHING_ENABLED: 'true'

--- a/src/main/java/it/gov/pagopa/wispconverter/servicebus/RTConsumer.java
+++ b/src/main/java/it/gov/pagopa/wispconverter/servicebus/RTConsumer.java
@@ -33,7 +33,7 @@ import java.util.List;
 @Component
 @Slf4j
 public class RTConsumer extends SBConsumer {
-    @Value("${wisp-converter.rt-send.max-retries:48}")
+    @Value("${wisp-converter.rt-send.max-retries:5}")
     private Integer maxRetries;
 
     @Value("${wisp-converter.rt-send.scheduling-time-in-minutes:60}")

--- a/src/test/java/it/gov/pagopa/wispconverter/consumer/ConsumerTest.java
+++ b/src/test/java/it/gov/pagopa/wispconverter/consumer/ConsumerTest.java
@@ -103,7 +103,7 @@ class ConsumerTest {
         ReflectionTestUtils.setField(rtConsumer, "reService", reService);
         ReflectionTestUtils.setField(rtConsumer, "idempotencyService", idempotencyService);
         ReflectionTestUtils.setField(rtConsumer, "jaxbElementUtil", jaxbElementUtil);
-        ReflectionTestUtils.setField(rtConsumer, "maxRetries", 48);
+        ReflectionTestUtils.setField(rtConsumer, "maxRetries", 5);
 
         rtConsumer.processMessage(messageContext);
 
@@ -169,7 +169,7 @@ class ConsumerTest {
         ReflectionTestUtils.setField(rtConsumer, "reService", reService);
         ReflectionTestUtils.setField(rtConsumer, "idempotencyService", idempotencyService);
         ReflectionTestUtils.setField(rtConsumer, "jaxbElementUtil", jaxbElementUtil);
-        ReflectionTestUtils.setField(rtConsumer, "maxRetries", 48);
+        ReflectionTestUtils.setField(rtConsumer, "maxRetries", 5);
 
         rtConsumer.processMessage(messageContext);
 
@@ -227,7 +227,7 @@ class ConsumerTest {
         ReflectionTestUtils.setField(rtConsumer, "reService", reService);
         ReflectionTestUtils.setField(rtConsumer, "idempotencyService", idempotencyService);
         ReflectionTestUtils.setField(rtConsumer, "jaxbElementUtil", jaxbElementUtil);
-        ReflectionTestUtils.setField(rtConsumer, "maxRetries", 48);
+        ReflectionTestUtils.setField(rtConsumer, "maxRetries", 5);
 
         rtConsumer.processMessage(messageContext);
 
@@ -262,7 +262,7 @@ class ConsumerTest {
         JaxbElementUtil jaxbElementUtil = new JaxbElementUtil();
 
         RTRetryRepository rtRetryRepository = mock(RTRetryRepository.class);
-        when(rtRetryRepository.findById(any(), any())).thenReturn(Optional.ofNullable(getStoredReceipt(48, receiptType, "http://endpoint:443")));
+        when(rtRetryRepository.findById(any(), any())).thenReturn(Optional.ofNullable(getStoredReceipt(5, receiptType, "http://endpoint:443")));
         RtRetryComosService rtRetryComosService = new RtRetryComosService(reService, rtRetryRepository);
         ReflectionTestUtils.setField(rtRetryComosService, "isTracingOnREEnabled", true);
 
@@ -284,7 +284,7 @@ class ConsumerTest {
         ReflectionTestUtils.setField(rtConsumer, "reService", reService);
         ReflectionTestUtils.setField(rtConsumer, "idempotencyService", idempotencyService);
         ReflectionTestUtils.setField(rtConsumer, "jaxbElementUtil", jaxbElementUtil);
-        ReflectionTestUtils.setField(rtConsumer, "maxRetries", 48);
+        ReflectionTestUtils.setField(rtConsumer, "maxRetries", 5);
 
         rtConsumer.processMessage(messageContext);
 


### PR DESCRIPTION
This PR contains a little update on parameter used to define the number of retries: the number pass from 48 to only 5 tries. The configuration key used by Nodo dei Pagamenti is not used on this scope because it would cause a logic refactoring not essentially needed for this scope.

#### List of Changes
 - Refactored number of retries for `paaInviaRT` send 

#### Motivation and Context
This change is required in order to better align to Nodo dei Pagamenti behavior on `paaInviaRT` send.

#### How Has This Been Tested?
 - Tested in local environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
