### PR TITLE
fix (receipts): [PAGOPA-2353] guard check added, avoiding out-of-bound exception

### DIFF
--- a/src/main/java/it/gov/pagopa/wispconverter/util/ReceiptRequestHandler.java
+++ b/src/main/java/it/gov/pagopa/wispconverter/util/ReceiptRequestHandler.java
@@ -1,78 +1,71 @@
 package it.gov.pagopa.wispconverter.util;
 
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 import org.springframework.stereotype.Component;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-
 @Data
-@EqualsAndHashCode(callSuper=false)
+@EqualsAndHashCode(callSuper = false)
 @Component
 public class ReceiptRequestHandler extends DefaultHandler {
-	
+
     private static final String NOTICE_NUMBER = "noticeNumber";
     private static final String FISCAL_CODE = "fiscalCode";
     private static final String CREDITOR_REFERENCE_ID = "creditorReferenceId";
-	
-	private PaSendRTV2Request paSendRTV2Request;
-	private StringBuilder elementValue;
-	
-	@Override
+
+    private PaSendRTV2Request paSendRTV2Request;
+    private StringBuilder elementValue;
+
+    @Override
     public void characters(char[] ch, int start, int length) throws SAXException {
         if (elementValue == null) {
             elementValue = new StringBuilder();
-        } else {
+        } else if (start + length <= ch.length) {
             elementValue.append(ch, start, length);
         }
     }
-	
-	@Override
-    public void startDocument() throws SAXException {
-		paSendRTV2Request = new PaSendRTV2Request();
-    }
-	
-	@Override
-	public void startElement(String uri, String lName, String qName, Attributes attr) throws SAXException {
-		switch (qName) {
-		case NOTICE_NUMBER:
-			elementValue = new StringBuilder();
-			break;
-		case FISCAL_CODE:
-			elementValue = new StringBuilder();
-			break;
-		case CREDITOR_REFERENCE_ID:
-			elementValue = new StringBuilder();
-			break;
-		default:
-			break;
-		}
-	}
 
-	@Override
+    @Override
+    public void startDocument() throws SAXException {
+        paSendRTV2Request = new PaSendRTV2Request();
+    }
+
+    @Override
+    public void startElement(String uri, String lName, String qName, Attributes attr) throws SAXException {
+        switch (qName) {
+            case NOTICE_NUMBER, FISCAL_CODE, CREDITOR_REFERENCE_ID:
+                elementValue = new StringBuilder();
+                break;
+            default:
+                break;
+        }
+    }
+
+    @Override
     public void endElement(String uri, String localName, String qName) throws SAXException {
         switch (qName) {
             case NOTICE_NUMBER:
-            	paSendRTV2Request.setNoticeNumber(elementValue.toString());
+                paSendRTV2Request.setNoticeNumber(elementValue.toString());
                 break;
             case FISCAL_CODE:
-            	paSendRTV2Request.setFiscalCode(elementValue.toString());
+                paSendRTV2Request.setFiscalCode(elementValue.toString());
                 break;
             case CREDITOR_REFERENCE_ID:
-            	paSendRTV2Request.setCreditorReferenceId(elementValue.toString());
-    			break;
-    		default:
-    			break;
+                paSendRTV2Request.setCreditorReferenceId(elementValue.toString());
+                break;
+            default:
+                break;
         }
     }
-	
-	@Data
-	public class PaSendRTV2Request{
-	    private String noticeNumber;
-	    private String fiscalCode;
-	    private String creditorReferenceId;   
-	}
+
+    @Data
+    public class PaSendRTV2Request {
+        private String noticeNumber;
+        private String fiscalCode;
+        private String creditorReferenceId;
+    }
 
 }


### PR DESCRIPTION
This PR contains a little fix made on a logging method, made in order to trying to resolve the IndexOutOfBoundsException that sometimes occurs on data extraction.

#### List of Changes
 - Add guard clause on logging method in order to fix exception

#### Motivation and Context
This fix is required in order to reduce out-of-bound exceptions.

#### How Has This Been Tested?
 - Tested in local environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
