### PR TITLE
[PIDM-587] fix: Remove `sanitizeInput` from SLF4J's MDC

### DIFF
--- a/src/main/java/it/gov/pagopa/wispconverter/service/ReceiptService.java
+++ b/src/main/java/it/gov/pagopa/wispconverter/service/ReceiptService.java
@@ -764,7 +764,7 @@ public class ReceiptService {
         String sessionId = rptRequestEntity.getId();
         // log event
         log.debug("[sendRTKoFromRPTRequestEntity] Processing session id: {}", sanitizeInput(sessionId));
-        MDC.put(Constants.MDC_SESSION_ID, sanitizeInput(sessionId));
+        MDC.put(Constants.MDC_SESSION_ID, sessionId);
 
         // delete key '2_wisp_timer_hang_{wisp_delete_sessionId}' from cache via APIM call
         it.gov.pagopa.gen.wispconverter.client.decouplercaching.model.SessionIdDto sessionIdDto = new it.gov.pagopa.gen.wispconverter.client.decouplercaching.model.SessionIdDto();


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- The `sanitizeInput` call has been removed when enriching the MDC.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

When the Support API `/recovery/receipts/koByRpt` is called, the `sessionId` is rewritten to `suspicious input` because sanitization is performed in `SLF4J MDC`, and this update `sessionData` object.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
